### PR TITLE
Allow yaxis as an additional prop, so it updates properly

### DIFF
--- a/src/ApexCharts.component.js
+++ b/src/ApexCharts.component.js
@@ -83,7 +83,8 @@ export default {
           height: this.height,
           width: this.width
         },
-        series: this.series
+        series: this.series,
+        yaxis: this.yaxis
       }
 
       const config = ApexCharts.merge(this.options, newOptions);


### PR DESCRIPTION
Fixes #11

I don't think this is or needs to be a breaking change. Previous behaviour of putting `yaxis` in the `options` prop will still work, albeit with the same, existing, non-updating behaviour.