### PR TITLE
Remove type requires

### DIFF
--- a/src/ApexCharts.component.js
+++ b/src/ApexCharts.component.js
@@ -7,7 +7,6 @@ export default {
     },
     type: {
       type: String,
-      required: true,
       default: 'line'
     },
     series: {


### PR DESCRIPTION
Is required is enables the option for milti plot graph is breaked, because the char type is in series...
const options = {
  chart: {
    height: 350,
    type: "line",
    toolbar: {
      show: true,
      tools: {
        download: true,
        selection: true,
        zoom: true,
        zoomin: true,
        zoomout: true,
        pan: true,
        reset: true
      },
      autoSelected: "zoom"
    }
  },
  series: [
    {
      name: "Website Blog",
      type: "column",
      data: [440, 505, 414, 671, 227, 413, 150, 352, 752, 320, 257, 160]
    },
    {
      name: "Social Media",
      type: "line",
      data: [23, 423, 35, 27, 43, 22, 17, 31, 22, 22, 12, 16]
    }
  ],
  stroke: {
    width: [0, 4]
  },
  title: {
    text: "Traffic Sources"
  },
  // labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
  labels: [
    "01 Jan 2001",
    "02 Jan 2001",
    "03 Jan 2001",
    "04 Jan 2001",
    "05 Jan 2001",
    "06 Jan 2001",
    "07 Jan 2001",
    "08 Jan 2001",
    "09 Jan 2001",
    "10 Jan 2001",
    "11 Jan 2001",
    "12 Jan 2001"
  ],
  xaxis: {
    type: "datetime"
  }
};