### PR TITLE
Default value of the typ

### DIFF
--- a/src/ApexCharts.component.js
+++ b/src/ApexCharts.component.js
@@ -6,8 +6,7 @@ export default {
       type: Object
     },
     type: {
-      type: String,
-      default: 'line'
+      type: String
     },
     series: {
       type: Array,
@@ -69,7 +68,7 @@ export default {
     init () {
       const newOptions = {
         chart: {
-          type: this.type,
+          type: this.type || this.options.chart.type || 'line',
           height: this.height,
           width: this.width,
           events: {}


### PR DESCRIPTION
My proposal is to take `chartOptions.chart.type` into consideration when creating a chart. The default prop value overwrites it resulting in sort-of inconsistency between chart creation in apex and vue-apex. I've spend an hour wondering why doesn't gradient fill work whilst the chart type was still set to default `line`.