### PR TITLE
applying patch for Safari

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,18 @@ VueApexCharts.install = function (Vue) {
             return ApexCharts
         }
     });
+  
+  const fill = window.SVG.Gradient.prototype.fill;
+  window.Gradient.prototype.fill = function (...args) {
+    const url = fill.apply(this, args);
+    const prefix = `url(${document.location.href}`;
+
+    if (!url.startsWith(prefix)) {
+      return url.split('url(').join(prefix);
+    }
+
+    return url;
+  };
 };
 
 export default VueApexCharts


### PR DESCRIPTION
I saw this patch and am affected by the issue it proposes to resolve, but it seems it has not yet been applied, so I am creating a pull request seeking to have the patch applied so my charts display correctly in Safari browsers, both desktop and iOS.

I have also created a ticket for this bug providing a sample SVG file generated by vue-apexcharts.