### PR TITLE
GH-234 refactor typings to expose VueApexChartConfig

### DIFF
--- a/dist/vue-apexcharts.d.ts
+++ b/dist/vue-apexcharts.d.ts
@@ -2,16 +2,24 @@ import Vue, { Component, ComponentOptions } from 'vue';
 import { PluginObject } from 'vue/types/plugin';
 import ApexCharts, { ApexOptions } from 'apexcharts';
 
-interface VueApexChartsComponent extends Vue {
-  // data
-  readonly chart?: ApexCharts;
-  // props
-  options?: ApexOptions;
+// this interface matches the exposed properties to enable straightforward
+// and strongly typed binding to the <apexchart> component properties
+// (see: https://apexcharts.com/docs/vue-charts/#props)
+export interface VueApexChartConfig {
   type?: 'line' | 'area' | 'bar' | 'histogram' | 'pie' | 'donut' | 'radialBar' | 'rangeBar' | 'scatter' | 'bubble' | 'heatmap' | 'candlestick' | 'radar' | 'polarArea' | 'treemap' | 'boxPlot';
   series: any;
-  width?: string | number;
   height?: string | number;
-  // method
+  width?: string | number;
+  options?: ApexOptions;
+}
+
+export interface VueApexChartsComponent extends VueApexChartConfig, Vue {
+  // data
+  readonly chart?: ApexCharts;
+
+  // props (see: VueApexChartConfig)
+
+  // methods
   init(): Promise<void>;
   refresh(): Promise<void>;
   destroy(): void;

--- a/dist/vue-apexcharts.js
+++ b/dist/vue-apexcharts.js
@@ -219,8 +219,8 @@
       addShape: function addShape(options) {
         this.chart.addShape(options);
       },
-      dataURI: function dataURI() {
-        return this.chart.dataURI();
+      dataURI: function dataURI(options) {
+        return this.chart.dataURI(options);
       },
       setLocale: function setLocale(localeName) {
         return this.chart.setLocale(localeName);

--- a/typings/vue-apexcharts.d.ts
+++ b/typings/vue-apexcharts.d.ts
@@ -2,16 +2,24 @@ import Vue, { Component, ComponentOptions } from 'vue';
 import { PluginObject } from 'vue/types/plugin';
 import ApexCharts, { ApexOptions } from 'apexcharts';
 
-interface VueApexChartsComponent extends Vue {
-  // data
-  readonly chart?: ApexCharts;
-  // props
-  options?: ApexOptions;
+// this interface matches the exposed properties to enable straightforward
+// and strongly typed binding to the <apexchart> component properties
+// (see: https://apexcharts.com/docs/vue-charts/#props)
+export interface VueApexChartConfig {
   type?: 'line' | 'area' | 'bar' | 'histogram' | 'pie' | 'donut' | 'radialBar' | 'rangeBar' | 'scatter' | 'bubble' | 'heatmap' | 'candlestick' | 'radar' | 'polarArea' | 'treemap' | 'boxPlot';
   series: any;
-  width?: string | number;
   height?: string | number;
-  // method
+  width?: string | number;
+  options?: ApexOptions;
+}
+
+export interface VueApexChartsComponent extends VueApexChartConfig, Vue {
+  // data
+  readonly chart?: ApexCharts;
+
+  // props (see: VueApexChartConfig)
+
+  // methods
   init(): Promise<void>;
   refresh(): Promise<void>;
   destroy(): void;


### PR DESCRIPTION
- exported `VueApexChartComponent` so that clients can import it
  and have access to the type declaration

- extracted (and exported) `VueApexChartConfig` from `VueApexChartComponent`
  as a new interface to wrap only the `apexchart` component props; this
  will allow clients to import `VueApexChartConfig` and type the
  properties without having to implement the other properties of Vue
  or the methods on the `VueApexChartComponent` interface.

- the `VueApexChartComponent` interface now extends both `Vue` and the
  new `VueApexChartConfig` interface, meaning that to the typescript
  compiler the `VueApexChartComponent` looks identical to how it
  looked before this PR.