### PR TITLE
fix watchers order

### DIFF
--- a/src/ApexCharts.component.js
+++ b/src/ApexCharts.component.js
@@ -32,6 +32,13 @@ export default {
     this.init();
   },
   created() {
+    let watched = ["type", "width", "height"];
+    watched.forEach(prop => {
+      this.$watch(prop, () => {
+        this.refresh();
+      });
+    });
+
     this.$watch("options", options => {
       if (!this.chart && options) {
         this.init();
@@ -46,12 +53,6 @@ export default {
       } else {
         this.chart.updateSeries(this.series);
       }
-    });
-    let watched = ["type", "width", "height"];
-    watched.forEach(prop => {
-      this.$watch(prop, () => {
-        this.refresh();
-      });
     });
   },
   beforeUnmount() {


### PR DESCRIPTION
# problem
If we update type & options at the same time, vuejs will trigger options watcher first, and after that type watcher. because of that, we get errors
# example
try to change a chart from line to pie chart you will get this error.
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'yRatio')
    at Line.draw (apexcharts.js?8eeb:22289:1)
    at Core.plotChartType (apexcharts.js?8eeb:24490:1)
    at ApexCharts.create (apexcharts.js?8eeb:31169:1)
    at ApexCharts.eval (apexcharts.js?8eeb:304:1)
    at eval (apexcharts.js?8eeb:31460:1)
    at new Promise (<anonymous>)
    at ApexCharts.update (apexcharts.js?8eeb:31455:1)
    at eval (apexcharts.js?8eeb:24923:1)
    at Array.forEach (<anonymous>)
    at eval (apexcharts.js?8eeb:24873:1)
```

# solution
if we change the order of watchers vuejs first trigger type and then options and it will fix the error.